### PR TITLE
[BUGFIX] Fix logic for updateText.

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -97,18 +97,18 @@
       file.model = model;
       if (model.version !== model.astVersion) {
         infer.withContext(srv.cx, function () {
-          file.ast = parseFile(srv, file)
+          model.ast = parseFile(srv, file);
+          model.astVersion = model.version;
         });
-        model.ast = file.ast;
-        model.astVersion = model.version;
       }
-      file.lineOffsets = null;
-      return;
+      file.ast = model.ast;
+      file.astVersion = model.astVersion;
+    } else {
+      file.text = srv.options.stripCRs ? text.replace(/\r\n/g, "\n") : text;
+      infer.withContext(srv.cx, function () {
+        file.ast = parseFile(srv, file)
+      });
     }
-    file.text = srv.options.stripCRs ? text.replace(/\r\n/g, "\n") : text;
-    infer.withContext(srv.cx, function() {
-      file.ast = parseFile(srv, file)
-    });
     file.lineOffsets = null;
   }
 


### PR DESCRIPTION
[DESC.] It sometimes overwrites valid ASTs with `null` and can result in errors in `walk.js`. This patch prevents overwriting valid ASTs.
